### PR TITLE
Fixed volume retrieval regex and temperature on virtual DSM

### DIFF
--- a/check_snmp_synology
+++ b/check_snmp_synology
@@ -383,7 +383,7 @@ else
             # in this case the former grep failed with more then one result.
             # modified script to look for a line with '= "/volume1"' instead of 'volume1'
             #storageID[$i]=$(echo "$syno_diskspace" | grep ${storageName[$i]} | cut -d "=" -f1 | rev | cut -d "." -f1 | rev)
-            storageID[$i]=$(echo "$syno_diskspace" | grep -i "= \"\?/${storageName[$i]}\"\?" | cut -d "=" -f1 | rev | cut -d "." -f1 | rev)
+            storageID[$i]=$(echo "$syno_diskspace" | grep -i "= \"\?/${storageName[$i]}\"" | cut -d "=" -f1 | rev | cut -d "." -f1 | rev)
 
             if [ "${storageID[$i]}" != "" ] ; then
                 storageSize[$i]=$(echo "$syno_diskspace" | grep "$OID_StorageSize.${storageID[$i]}" | cut -d "=" -f2 )

--- a/check_snmp_synology
+++ b/check_snmp_synology
@@ -428,7 +428,7 @@ else
                           echo "$healthString System Status:             $systemStatus" ;;
         "version")        echo "DSM Version: $DSMVersion $healthString" ;
                           echo "DSM update:              $DSMUpgradeAvailable" ;;
-        "temperature")    echo "$healthString Temperature:                " ;;
+        "temperature")    echo "$healthString Temperature:               $temperature" ;;
         "power")          echo "$healthString Power Status:              $powerStatus" ;;
         "fan")            echo "$healthString System Fan Status:         $systemFanStatus" ;
                           echo "CPU Fan Status:          $CPUFanStatus" ;;

--- a/check_snmp_synology
+++ b/check_snmp_synology
@@ -286,8 +286,8 @@ else
     fi
 
     if [ "$checkType" = "temperature" ] ; then
-        #Check system temperature
-        if [ "$temperature" -gt "$warningTemperature" ] ; then
+        #Check system temperature (no such OID on virtual DSMs)
+        if [[ "$temperature" =~ ^[0-9.]+$ ]] && [ "$temperature" -gt "$warningTemperature" ] ; then
             if [ "$temperature" -gt "$criticalTemperature" ] ; then
                     temperature="$temperature (CRITICAL)"
                     healthCriticalStatus=1


### PR DESCRIPTION
* we only want the first line, e.g. ${storageName[$i]} teminated by a double quote

.1.3.6.1.2.1.25.2.3.1.3.56 = "/volume1"
.1.3.6.1.2.1.25.2.3.1.3.75 = "/volume1/@docker"
.1.3.6.1.2.1.25.2.3.1.3.76 = "/volume1/@docker/btrfs" .1.3.6.1.2.1.25.2.3.1.3.77 = "/volume1/@appdata/ContainerManager/all_shares/ActiveBackupforBusiness" .1.3.6.1.2.1.25.2.3.1.3.78 = "/volume1/@appdata/ContainerManager/all_shares/Administration" .1.3.6.1.2.1.25.2.3.1.3.79 = "/volume1/@appdata/ContainerManager/all_shares/Backup"

* Virtual DSMs don't expose the temperature OID